### PR TITLE
Deploy key flag needs -, not _, at least in 1.2.2.0

### DIFF
--- a/threatstack/init.sls
+++ b/threatstack/init.sls
@@ -38,5 +38,5 @@ install-threatstack-agent:
 cloudsight-setup:
   cmd.run:
     - cwd: /
-    - name: cloudsight setup --deploy_key={{threatstack.deploy_key}}
+    - name: cloudsight setup --deploy-key={{threatstack.deploy_key}}
     - unless: test -f /opt/threatstack/cloudsight/config/.secret


### PR DESCRIPTION
Simple change, flag was using _ instead of -.