### PR TITLE
Fix for disable-auditd-amazonlinux on non-Amazon OS

### DIFF
--- a/threatstack/init.sls
+++ b/threatstack/init.sls
@@ -76,8 +76,8 @@ threatstack-repo:
 
 # Shutdown and disable auditd
 # Sometimes the agent install scripts can't do it on Amazon Linux
-disable-auditd-amazonlinux:
 {% if grains['os']=="Amazon" %}
+disable-auditd-amazonlinux:
   name: auditd
   service.dead:
     - enable: False


### PR DESCRIPTION
If running the state on a non-Amazon OS (like Ubuntu), the `disable-auditd-amazonlinux` fails because it is not a valid state (it ends up being just `disable-auditd-amazonlinux:` with nothing after).