### PR TITLE
Fetch config values from threatstack key

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -17,16 +17,17 @@ provisioner:
     # Use this section (and comment out the `pillars_from_files` section)
     # to grab pillar data from environment variables
     # threatstack.sls:
-    #   deploy_key: <%= ENV['TS_DEPLOY_KEY'] != nil ? ENV['TS_DEPLOY_KEY'] : 'ts_deploy_key' %>
-    #   ts_agent_version: <%= ENV['TS_PACKAGE_VERSION'] %>
+    #   threatstack:
+    #     deploy_key: <%= ENV['TS_DEPLOY_KEY'] != nil ? ENV['TS_DEPLOY_KEY'] : 'ts_deploy_key' %>
+    #     agent_version: <%= ENV['TS_PACKAGE_VERSION'] %>
     #   <% if ENV['TS_CONFIG_ARGS'] %>
-    #   ts_agent_config_args: <%= ENV['TS_CONFIG_ARGS'] %>
+    #     agent_config_args: <%= ENV['TS_CONFIG_ARGS'] %>
     #   <% end %>
-    #   ts_agent_version: <%= ENV['TS_PACKAGE_VERSION'] %>
-    # ts_configure_agent: <%= ENV['TS_CONFIGURE_AGENT'] %>
-    # ts_agent_latest: <%= ENV['TS_AGENT_LATEST'] %>
+    #     agent_version: <%= ENV['TS_PACKAGE_VERSION'] %>
+    #     configure_agent: <%= ENV['TS_CONFIGURE_AGENT'] %>
+    #     agent_latest: <%= ENV['TS_AGENT_LATEST'] %>
     #   <% if ENV['TS_SETUP_ARGS'] %>
-    #   ts_agent_extra_args: <%= ENV['TS_SETUP_ARGS'] %>
+    #     agent_extra_args: <%= ENV['TS_SETUP_ARGS'] %>
     #   <% end %>
   state_top:
     base:

--- a/pillar.example
+++ b/pillar.example
@@ -1,7 +1,8 @@
-pkg_url: 'https://mirror.example.com'
-deploy_key: "xxxx-xxxx-your-secret-key-xxxx"
-ts_configure_agent: True
-ts_agent_version: 1.4.5.0ubuntu14.0
-ts_agent_latest: True
-ts_agent_config_args: '--enable_foo=1'
-ts_agent_extra_args: ''
+threatstack:
+  pkg_url: 'https://mirror.example.com'
+  deploy_key: "xxxx-xxxx-your-secret-key-xxxx"
+  configure_agent: True
+  agent_version: 1.4.5.0ubuntu14.0
+  agent_latest: True
+  agent_config_args: '--enable_foo=1'
+  agent_extra_args: ''


### PR DESCRIPTION
Rather than looking for config values at the top level, it is better to nest them under a `threatstack` key. This is cleaner to read and prevents conflicts in variable names.