### PR TITLE
correctly format the disable-auditd-amazonlinux state as a list

### DIFF
--- a/threatstack/init.sls
+++ b/threatstack/init.sls
@@ -78,8 +78,8 @@ threatstack-repo:
 # Sometimes the agent install scripts can't do it on Amazon Linux
 {% if grains['os']=="Amazon" %}
 disable-auditd-amazonlinux:
-  name: auditd
   service.dead:
+    - name: auditd
     - enable: False
 {% endif %}
 


### PR DESCRIPTION
With the current format of this state, I received the following error upon trying to apply Salt state:

```State 'disable-auditd-amazonlinux' in SLS 'threatstack' is not formed as a list```

This change reformats the state to a proper YAML list.