### PR TITLE
Fix a case where the code would not configure a custom `pkg_url`.

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -4,7 +4,6 @@ driver:
 
 provisioner:
   name: salt_solo
-  bootstrap_url: 'https://raw.githubusercontent.com/olhado/kitchen-salt/master/assets/install.sh'
   is_file_root: true
   # Use this section (and comment out the `threatstack.sls` definition in the `pillars` section)
   # to grab pillar data from the `pillar.example` file
@@ -39,6 +38,8 @@ provisioner:
 platforms:
   - name: amazonlinux-1
     image: amazonlinux:1
+    provisioner:
+      salt_bootstrap_options: -R archive.repo.saltproject.io
     driver_config:
       run_command: /sbin/init
       privileged: true
@@ -63,6 +64,7 @@ platforms:
         - /sys/fs/cgroup:/sys/fs/cgroup
       provision_command:
         - amazon-linux-extras install ruby2.6
+        - yum -y groupinstall "Development Tools"
         - yum install -y ruby-devel gcc make
         - gem install io-console --install-dir=/tmp/verifier/gems
         - chown -R kitchen:kitchen /tmp/verifier
@@ -104,25 +106,6 @@ platforms:
         - yum install -y audit initscripts
         - sed -i 's/local_events = yes/local_events = no/g' /etc/audit/auditd.conf
         - systemctl enable auditd.service
-  - name: debian-8
-    image: debian:8
-    driver_config:
-      run_command: /sbin/init
-      cap_add:
-        - SYS_ADMIN
-      run_options:
-        env: container=docker
-      volume:
-        - /sys/fs/cgroup:/sys/fs/cgroup
-      provision_command:
-        - |
-          apt-get install -y checkinstall build-essential zlib1g-dev libssl-dev libreadline6-dev libyaml-dev wget && \
-          wget https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.6.tar.gz && \
-          tar xfz ruby-2.6.6.tar.gz && \
-          echo "364b143def360bac1b74eb56ed60b1a0dca6439b00157ae11ff77d5cd2e92291 ruby-2.6.6.tar.gz" | sha256sum -c && \
-          cd ruby-2.6.6 && ./configure && make && make install && rm ../ruby-2.6.6.tar.gz
-        - sed -i 's/UsePAM yes/UsePAM no/g' /etc/ssh/sshd_config
-        - systemctl enable ssh.service
   - name: debian-9
     image: debian:9
     driver_config:
@@ -138,19 +121,6 @@ platforms:
         - systemctl enable ssh.service
   - name: debian-10
     image: debian:10
-    driver_config:
-      run_command: /sbin/init
-      cap_add:
-        - SYS_ADMIN
-      run_options:
-        env: container=docker
-      volume:
-        - /sys/fs/cgroup:/sys/fs/cgroup
-      provision_command:
-        - sed -i 's/UsePAM yes/UsePAM no/g' /etc/ssh/sshd_config
-        - systemctl enable ssh.service
-  - name: ubuntu-16.04
-    image: ubuntu:16.04
     driver_config:
       run_command: /sbin/init
       cap_add:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -37,10 +37,10 @@ provisioner:
 
 platforms:
   - name: amazonlinux-1
-    image: amazonlinux:1
     provisioner:
       salt_bootstrap_options: -R archive.repo.saltproject.io
     driver_config:
+      image: amazonlinux:1
       run_command: /sbin/init
       privileged: true
       run_options:
@@ -54,8 +54,26 @@ platforms:
         - sed -i 's/local_events = yes/local_events = no/g' /etc/audit/auditd.conf
         - chkconfig auditd on
   - name: amazonlinux-2
-    image: amazonlinux:2
     driver_config:
+      image: amazonlinux:2
+      run_command: /sbin/init
+      privileged: true
+      run_options:
+        env: container=docker
+      volume:
+        - /sys/fs/cgroup:/sys/fs/cgroup
+      provision_command:
+        - amazon-linux-extras install ruby2.6
+        - yum -y groupinstall "Development Tools"
+        - yum install -y ruby-devel gcc make
+        - gem install io-console --install-dir=/tmp/verifier/gems
+        - chown -R kitchen:kitchen /tmp/verifier
+        - yum install -y audit initscripts
+        - sed -i 's/local_events = yes/local_events = no/g' /etc/audit/auditd.conf
+        - systemctl enable auditd.service
+  - name: amazonlinux-2-arm
+    driver_config:
+      image: arm64v8/amazonlinux:2
       run_command: /sbin/init
       privileged: true
       run_options:
@@ -72,8 +90,8 @@ platforms:
         - sed -i 's/local_events = yes/local_events = no/g' /etc/audit/auditd.conf
         - systemctl enable auditd.service
   - name: centos-7
-    image: centos:7
     driver_config:
+      image: centos:7
       run_command: /sbin/init
       privileged: true
       run_options:
@@ -94,8 +112,21 @@ platforms:
         - sed -i 's/local_events = yes/local_events = no/g' /etc/audit/auditd.conf
         - systemctl enable auditd.service
   - name: centos-8
-    image: centos:8
     driver_config:
+      image: centos:8
+      run_command: /sbin/init
+      privileged: true
+      run_options:
+        env: container=docker
+      volume:
+        - /sys/fs/cgroup:/sys/fs/cgroup
+      provision_command:
+        - yum install -y audit initscripts
+        - sed -i 's/local_events = yes/local_events = no/g' /etc/audit/auditd.conf
+        - systemctl enable auditd.service
+  - name: centos-8
+    driver_config:
+      image: arm64v8/centos:8
       run_command: /sbin/init
       privileged: true
       run_options:
@@ -107,8 +138,8 @@ platforms:
         - sed -i 's/local_events = yes/local_events = no/g' /etc/audit/auditd.conf
         - systemctl enable auditd.service
   - name: debian-9
-    image: debian:9
     driver_config:
+      image: debian:9
       run_command: /bin/systemd
       cap_add:
         - SYS_ADMIN
@@ -120,8 +151,21 @@ platforms:
         - sed -i 's/UsePAM yes/UsePAM no/g' /etc/ssh/sshd_config
         - systemctl enable ssh.service
   - name: debian-10
-    image: debian:10
     driver_config:
+      image: debian:10
+      run_command: /sbin/init
+      cap_add:
+        - SYS_ADMIN
+      run_options:
+        env: container=docker
+      volume:
+        - /sys/fs/cgroup:/sys/fs/cgroup
+      provision_command:
+        - sed -i 's/UsePAM yes/UsePAM no/g' /etc/ssh/sshd_config
+        - systemctl enable ssh.service
+  - name: debian-10-arm
+    driver_config:
+      image: arm64v8/debian:10
       run_command: /sbin/init
       cap_add:
         - SYS_ADMIN
@@ -133,8 +177,21 @@ platforms:
         - sed -i 's/UsePAM yes/UsePAM no/g' /etc/ssh/sshd_config
         - systemctl enable ssh.service
   - name: ubuntu-18.04
-    image: ubuntu:18.04
     driver_config:
+      image: ubuntu:18.04
+      run_command: /sbin/init
+      cap_add:
+        - SYS_ADMIN
+      run_options:
+        env: container=docker
+      volume:
+        - /sys/fs/cgroup:/sys/fs/cgroup
+      provision_command:
+        - sed -i 's/UsePAM yes/UsePAM no/g' /etc/ssh/sshd_config
+        - systemctl enable ssh.service
+  - name: ubuntu-18.04-arm
+    driver_config:
+      image: arm64v8/ubuntu:18.04
       run_command: /sbin/init
       cap_add:
         - SYS_ADMIN
@@ -146,8 +203,21 @@ platforms:
         - sed -i 's/UsePAM yes/UsePAM no/g' /etc/ssh/sshd_config
         - systemctl enable ssh.service
   - name: ubuntu-20.04
-    image: ubuntu:20.04
     driver_config:
+      image: ubuntu:20.04
+      run_command: /sbin/init
+      cap_add:
+        - SYS_ADMIN
+      run_options:
+        env: container=docker
+      volume:
+        - /sys/fs/cgroup:/sys/fs/cgroup
+      provision_command:
+        - sed -i 's/UsePAM yes/UsePAM no/g' /etc/ssh/sshd_config
+        - systemctl enable ssh.service
+  - name: ubuntu-20.04-arm
+    driver_config:
+      image: arm64v8/ubuntu:20.04
       run_command: /sbin/init
       cap_add:
         - SYS_ADMIN

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -13,5 +13,11 @@ end
 
 describe command('tsagent status') do
   # Sometimes due to other services, like auditd, the install would be successful, but then this service would get killed
-  its(:stdout) { should match /UP Threat Stack Audit Collection/ } # rubocop: disable Lint/AmbiguousRegexpLiteral
+  its(:stdout) { should match /UP Threat Stack Agent Daemon/ } # rubocop: disable Lint/AmbiguousRegexpLiteral
+  its(:stdout) { should match /UP Threat Stack Backend Connection/ } # rubocop: disable Lint/AmbiguousRegexpLiteral
+  its(:stdout) { should match /UP Threat Stack Heartbeat Service/ } # rubocop: disable Lint/AmbiguousRegexpLiteral
+  its(:stdout) { should match /UP Threat Stack Login Collector/ } # rubocop: disable Lint/AmbiguousRegexpLiteral
+  its(:stdout) { should match /UP Threat Stack Log Scan Service/ } # rubocop: disable Lint/AmbiguousRegexpLiteral
+  its(:stdout) { should match /UP Threat Stack Vulnerability Scanner/ } # rubocop: disable Lint/AmbiguousRegexpLiteral
+  its(:stdout) { should match /UP Threat Stack File Integrity Monitor/ } # rubocop: disable Lint/AmbiguousRegexpLiteral
 end

--- a/threatstack/init.sls
+++ b/threatstack/init.sls
@@ -16,7 +16,7 @@
 {% endif %}
 
 # Check if OS is not supported in 2.X, and assign the repository URL appropriately
-{% if pkg_url is not defined %}
+{% if pillar['pkg_url'] is not defined %}
   {% set _ = pkg_location.update({ 'pkg_url': agent2_pkg_url_base}) %}
 
   # Set the rest of the URL path


### PR DESCRIPTION
* Changed test to check for the services that will be up. Starting in 2.3.4, the Audit Collection service is now marked down, since in containers the host agent can't get local audit events. This service is what was checked in the test before
* Removed platforms that salt considers EOL from test suite
* Updated Amazon Linux 1 test suite to use the right repository to grab the salt package
* Updated Amazon Linux 2 package to include some needed dev tools